### PR TITLE
feat(devbox): Add gcloud with auth-plugin, fix devbox scripts

### DIFF
--- a/.devbox/flakes/gcloud/flake.nix
+++ b/.devbox/flakes/gcloud/flake.nix
@@ -1,0 +1,23 @@
+{
+  description = "Google Cloud SDK with GKE auth plugin";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils}:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+        };
+      in {
+        packages = {
+          google-cloud-sdk = with pkgs; google-cloud-sdk.withExtraComponents [
+            google-cloud-sdk.components.gke-gcloud-auth-plugin
+          ];
+        };
+      }
+    );
+}

--- a/devbox.json
+++ b/devbox.json
@@ -14,9 +14,9 @@
       "(cd ./tests/helm-chart && helm dependency update)"
     ],
     "scripts": {
-      "test": "./resources/scripts/test.sh",
-      "lint": "./resources/scripts/lint.sh",
-      "publish": "./resources/scripts/publish.sh \"$@\""
+      "test": "${DEVBOX_PROJECT_ROOT}/resources/scripts/test.sh",
+      "lint": "${DEVBOX_PROJECT_ROOT}/resources/scripts/lint.sh",
+      "publish": "${DEVBOX_PROJECT_ROOT}/resources/scripts/publish.sh \"$@\""
     }
   }
 }

--- a/devbox.json
+++ b/devbox.json
@@ -4,7 +4,8 @@
     "kubernetes-helm@latest",
     "nodejs@23",
     "yq@latest",
-    "opentofu@1.8.8"
+    "opentofu@1.8.8",
+    "path:.devbox/flakes/gcloud#google-cloud-sdk"
   ],
   "shell": {
     "init_hook": [


### PR DESCRIPTION
This PR propose two things: 

* Add nix pkgs, from a flake, to install google-gloud-sdk with the gke-gcloud-auth-plugin.
* Fix `devbox run` scripts calls 

Details about `devbox run` fix

When calling `devbox run test`, the call of the script `./resources/scripts/test.sh` is done at last line of `.devbox/gen/script/test.sh` which is relative the directory `.devbox/gen/script`.

So, when runnin `devbox run test` from the root of the git directory, devbox
return this error :

```
/REDACTED/docker-gcp-private-mirror/.devbox/gen/scripts/test.sh: line 7: ./resources/scripts/test.sh: cannot execute: required file not found
Error: error running script "test" in Devbox: exit status 127
```

This PR fix this issues by calling `resources/scripts/*` using absolute path based on the devbox root project directory.